### PR TITLE
Improve BOT_TOKEN error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
    ```bash
    python bot.py
    ```
+   Если при запуске возникает ошибка вида `TypeError: 'NoneType' object is not`
+   `iterable`, убедитесь, что в файле `.env` указана переменная `BOT_TOKEN`.
 
 ## Deploy на Render
 На сервисе [Render](https://render.com) создайте новый **Web Service** из репозитория.

--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,12 @@ DB_PATH = os.getenv("DB_PATH", db.DB_PATH)
 
 logging.basicConfig(level=logging.INFO)
 
+if not BOT_TOKEN:
+    raise RuntimeError(
+        "BOT_TOKEN is not set. Create a .env file based on .env.example and "
+        "specify your Telegram bot token."
+    )
+
 bot = telebot.TeleBot(BOT_TOKEN, parse_mode="HTML")
 
 


### PR DESCRIPTION
## Summary
- raise a clear error when `BOT_TOKEN` is missing
- add troubleshooting note in README

## Testing
- `python -m py_compile bot.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6856bb809afc83248622d476466e9d24