### PR TITLE
Fix README env explanation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 BOT_TOKEN="<your-bot-token>"
 ADMIN_IDS=<admin-id>
+# Для нескольких администраторов используйте запятую: ADMIN_IDS=123,456
 DB_PATH=bot.db

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
    pip install -r requirements.txt
    ```
 2. Скопируйте файл `.env.example` в `.env` и подставьте свои значения вместо плейсхолдеров:
-   - `BOT_TOKEN` – токен вашего бота
+   - `BOT_TOKEN` – токен вашего бота (должен содержать двоеточие)
    - `ADMIN_IDS` – список ID администраторов через запятую
    - `DB_PATH` – путь к базе (опционально)
    
@@ -25,8 +25,8 @@
    ```bash
    python bot.py
    ```
-   Если при запуске возникает ошибка вида `TypeError: 'NoneType' object is not`
-   `iterable`, убедитесь, что в файле `.env` указана переменная `BOT_TOKEN`.
+   Если при запуске возникает ошибка вида `TypeError: 'NoneType' object is not iterable`,
+   убедитесь, что в файле `.env` указана переменная `BOT_TOKEN`.
 
 ## Deploy на Render
 На сервисе [Render](https://render.com) создайте новый **Web Service** из репозитория.


### PR DESCRIPTION
## Summary
- clarify that tokens must include a colon
- add example of multiple admins in `.env.example`

## Testing
- `python -m py_compile bot.py db.py`
- `flake8 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685ac90190b08324b4c1465312647257